### PR TITLE
Move orchestra/testbench back into dev dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,15 +27,15 @@
     "pestphp/pest-plugin-laravel": "^3.2.0",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.4",
-    "laravel/pint": "^1.22"
+    "laravel/pint": "^1.22",
+    "orchestra/testbench": "^9.0|^10.0"
   },
   "require": {
     "php": "^8.2",
     "illuminate/contracts": "^11.0|^12.0",
     "illuminate/support": "^11.0|^12.0",
     "illuminate/database": "^11.0|^12.0",
-    "laravel/framework": "^11.0|^12.0",
-    "orchestra/testbench": "^9.0|^10.0"
+    "laravel/framework": "^11.0|^12.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Revert changes from https://github.com/aliziodev/laravel-taxonomy/commit/dfe690d2a4598fe4b97a2b1cea3defeb42daad63