### PR TITLE
fix: getNestedTree with Model::shouldBeStrict()

### DIFF
--- a/src/Models/Taxonomy.php
+++ b/src/Models/Taxonomy.php
@@ -821,7 +821,7 @@ class Taxonomy extends Model
             } else {
                 // Child level - add to parent's children collection
                 $parent = end($stack);
-                if ($parent && ! $parent->children_nested) {
+                if ($parent && empty($parent->children_nested)) {
                     /** @var \Illuminate\Database\Eloquent\Collection<int, static> $childrenNested */
                     $childrenNested = new Collection;
                     $parent->setAttribute('children_nested', $childrenNested);

--- a/tests/Feature/NestedSetTest.php
+++ b/tests/Feature/NestedSetTest.php
@@ -3,6 +3,7 @@
 use Aliziodev\LaravelTaxonomy\Enums\TaxonomyType;
 use Aliziodev\LaravelTaxonomy\Models\Taxonomy;
 use Aliziodev\LaravelTaxonomy\Tests\TestCase;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(TestCase::class, RefreshDatabase::class);
@@ -327,4 +328,10 @@ it('works with different taxonomy types', function () {
 
     expect($techTag->isAncestorOf($electronics))->toBeFalse();
     expect($electronics->isAncestorOf($techTag))->toBeFalse();
+});
+
+it('works when models are strict', function () {
+    Model::shouldBeStrict();
+    $tree = Taxonomy::getNestedTree(TaxonomyType::Category);
+    expect($tree)->toHaveCount(2);
 });


### PR DESCRIPTION
When running this line:
```
Taxonomy::getNestedTree();
```

While having this in your configs/providers:
```
Model::shouldBeStrict();
```

The following error would result (assuming you have some rows):
```
Illuminate\Database\Eloquent\MissingAttributeException

The attribute [children_nested] either does not exist or was not retrieved for model [Aliziodev\LaravelTaxonomy\Models\Taxonomy].
```

This was fixed and a test was added